### PR TITLE
Fix deprecated set-output and git commit flag in update-data.yml

### DIFF
--- a/.github/workflows/update-data.yml
+++ b/.github/workflows/update-data.yml
@@ -30,10 +30,10 @@ jobs:
           git config --local user.email ${EMAIL_ADDRESS}
           git config --local user.name ${GIT_USER_NAME}
       - id: diff
-        run: echo "::set-output name=changed::$(git diff --name-only origin/main --relative packages/data | wc -l)"
+        run: echo "changed=$(git diff --name-only HEAD --relative packages/data | wc -l)" >> $GITHUB_OUTPUT
       - if: ${{ steps.diff.outputs.changed != '0' }}
         name: git push
         run: |
           git add packages/data/data.json
-          git commit -m "Update data `date "+%Y/%m/%d"`" -a
+          git commit -m "Update data `date "+%Y/%m/%d"`"
           git push origin main


### PR DESCRIPTION
- Replace ::set-output:: with $GITHUB_OUTPUT (deprecated since 2023/06)
- Change git diff base from origin/main to HEAD to avoid fetch requirement
- Remove -a flag from git commit to avoid unintended file inclusion

https://claude.ai/code/session_013X94eGF8YMYMDBuMtMF988