### PR TITLE
Fix GitHub Actions deploy error by replacing deprecated heroku/builder:24 with Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+.git
+.github
+node_modules
+apps/calendar/dist
+packages/data/*.js
+packages/schema/*.js
+packages/fetcher

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+FROM node:20-alpine
+
+WORKDIR /app
+
+# Copy workspace configuration
+COPY package.json yarn.lock turbo.json ./
+
+# Copy package.json files for all workspaces (for dependency layer caching)
+COPY apps/calendar/package.json ./apps/calendar/
+COPY packages/data/package.json ./packages/data/
+COPY packages/schema/package.json ./packages/schema/
+
+# Install all dependencies
+RUN yarn install --frozen-lockfile
+
+# Copy all source code
+COPY apps/calendar/ ./apps/calendar/
+COPY packages/data/ ./packages/data/
+COPY packages/schema/ ./packages/schema/
+
+# Build all workspaces
+RUN yarn build
+
+EXPOSE 8080
+
+CMD ["node", "apps/calendar/dist/index.js"]

--- a/apps/calendar/fly.toml
+++ b/apps/calendar/fly.toml
@@ -12,9 +12,7 @@ kill_timeout = "5s"
   auto_rollback = true
 
 [build]
-  builder = "heroku/builder:24"
-  [build.args]
-    NODE_VERSION = "20"
+  dockerfile = "../../Dockerfile"
 
 [env]
   PORT = "8080"

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -1,9 +1,13 @@
 {
   "name": "@tt-calendar/schema",
   "version": "0.0.0",
-  "main": "./index.ts",
+  "main": "./index.js",
   "types": "./index.ts",
   "license": "MIT",
+  "scripts": {
+    "build": "tsc",
+    "clean": "rimraf ./*.js"
+  },
   "dependencies": {
     "zod": "^3.19.1"
   }


### PR DESCRIPTION
- Add Dockerfile at repo root for Yarn workspace monorepo build
- Add .dockerignore to exclude unnecessary files from Docker build context
- Update apps/calendar/fly.toml to use Dockerfile instead of heroku/builder:24 (which is broken on Fly.io)
- Update packages/schema/package.json to add build script and change main to compiled JS output

https://claude.ai/code/session_01UeugP8X6VrkpiQ7eY46TVt